### PR TITLE
feat/회원가입, 로그인 API 구현, 토큰 발급 로직 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,51 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import Joi from 'joi';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+import { TypeOrmModule, TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { AuthModule } from './auth/auth.module';
+import { UserModule } from './user/user.module';
+import { User } from './user/entities/user.entity';
+import { Token } from './user/entities/tokens.entity';
+
+const typeOrmModuleOptions = {
+  useFactory: async (
+    configService: ConfigService,
+  ): Promise<TypeOrmModuleOptions> => ({
+    namingStrategy: new SnakeNamingStrategy(),
+    type: 'mysql',
+    username: configService.get('DB_USERNAME'),
+    password: configService.get('DB_PASSWORD'),
+    host: configService.get('DB_HOST'),
+    port: configService.get('DB_PORT'),
+    database: configService.get('DB_NAME'),
+    entities: [User, Token],
+    synchronize: configService.get('DB_SYNC'),
+    logging: true,
+  }),
+  inject: [ConfigService],
+};
 
 @Module({
-  imports: [],
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      validationSchema: Joi.object({
+        JWT_SECRET_KEY: Joi.string().required(),
+        DB_USERNAME: Joi.string().required(),
+        DB_PASSWORD: Joi.string().required(),
+        DB_HOST: Joi.string().required(),
+        DB_PORT: Joi.number().required(),
+        DB_NAME: Joi.string().required(),
+        DB_SYNC: Joi.boolean().required(),
+      }),
+    }),
+    TypeOrmModule.forRootAsync(typeOrmModuleOptions),
+    AuthModule,
+    UserModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { JwtStrategy } from './jwt.strategy';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { ConfigService } from '@nestjs/config';
+import { UserModule } from 'src/user/user.module';
+
+@Module({
+  imports: [
+    PassportModule.register({ defaultStrategy: 'jwt', session: false }),
+    JwtModule.registerAsync({
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('JWT_SECRET_KEY'),
+      }),
+      inject: [ConfigService],
+    }),
+    UserModule,
+  ],
+  providers: [JwtStrategy],
+})
+export class AuthModule {}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,0 +1,28 @@
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { UserService } from 'src/user/user.service';
+import _ from 'lodash';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(
+    private readonly userService: UserService,
+    private readonly configService: ConfigService,
+  ) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: configService.get('JWT_SECRET_KEY'),
+    });
+  }
+
+  async validate(payload: any) {
+    const user = await this.userService.findByEmail(payload.email);
+    if (_.isNil(user)) {
+      throw new NotFoundException('해당하는 사용자를 찾을 수 없습니다.');
+    }
+    return user;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,14 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+    }),
+  );
   await app.listen(3000);
 }
 bootstrap();

--- a/src/user/dto/signIn.dto.ts
+++ b/src/user/dto/signIn.dto.ts
@@ -1,0 +1,11 @@
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+
+export class SignInDto {
+  @IsEmail()
+  @IsNotEmpty({ message: '이메일을 입력해주세요.' })
+  email: string;
+
+  @IsString()
+  @IsNotEmpty({ message: '비밀번호를 입력해주세요.' })
+  password: string;
+}

--- a/src/user/dto/signUp.dto.ts
+++ b/src/user/dto/signUp.dto.ts
@@ -1,0 +1,15 @@
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+
+export class SignUpDto {
+  @IsEmail()
+  @IsNotEmpty({ message: '이메일을 입력해주세요.' })
+  email: string;
+
+  @IsString()
+  @IsNotEmpty({ message: '닉네임을 입력해주세요.' })
+  nickname: string;
+
+  @IsString()
+  @IsNotEmpty({ message: '비밀번호를 입력해주세요.' })
+  password: string;
+}

--- a/src/user/entities/tokens.entity.ts
+++ b/src/user/entities/tokens.entity.ts
@@ -1,0 +1,38 @@
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+
+@Entity({
+  name: 'tokens',
+})
+export class Token {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', nullable: true })
+  refreshToken: string;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updatedAt: Date;
+
+  @DeleteDateColumn({ type: 'timestamp' })
+  deletedAt: Date;
+
+  @OneToOne(() => User, (user) => user.token)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column({ type: 'int', name: 'user_id' })
+  userId: number;
+}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,0 +1,38 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Role } from '../types/userRole.type';
+import { Token } from './tokens.entity';
+
+@Entity({
+  name: 'users',
+})
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', unique: true, nullable: false })
+  email: string;
+
+  @Column({ type: 'varchar', unique: true, nullable: false })
+  nickname: string;
+
+  @Column({ type: 'varchar', select: false, nullable: false })
+  password: string;
+
+  @Column({ type: 'int', nullable: false, default: 1000000 })
+  point: number;
+
+  @Column({ type: 'enum', enum: Role, default: Role.User })
+  role: Role;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt: Date;
+
+  @OneToOne(() => Token, (token) => token.user)
+  token: Token;
+}

--- a/src/user/types/userRole.type.ts
+++ b/src/user/types/userRole.type.ts
@@ -1,0 +1,4 @@
+export enum Role {
+  User,
+  Admin,
+}

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserController } from './user.controller';
+
+describe('UserController', () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { UserService } from './user.service';
+import { SignUpDto } from './dto/signUp.dto';
+import { SignInDto } from './dto/signIn.dto';
+import { User } from './entities/user.entity';
+import { AuthGuard } from '@nestjs/passport';
+import { UserInfo } from 'src/utils/userInfo.decorator';
+
+@Controller('user')
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  @Post('sign-up')
+  async signUp(@Body() signUpDto: SignUpDto) {
+    const savedUser = await this.userService.signUp(
+      signUpDto.email,
+      signUpDto.nickname,
+      signUpDto.password,
+    );
+    return {
+      status: HttpStatus.CREATED,
+      message: '회원가입이 성공하였습니다.',
+      data: savedUser,
+    };
+  }
+
+  @Post('sign-in')
+  async signIn(@Body() signInDto: SignInDto) {
+    const tokens = await this.userService.signIn(
+      signInDto.email,
+      signInDto.password,
+    );
+    return {
+      status: HttpStatus.OK,
+      message: '로그인이 성공하였습니다.',
+      data: tokens,
+    };
+  }
+
+  @UseGuards(AuthGuard('jwt'))
+  @Get('me')
+  async getProfile(@UserInfo() user: User) {
+    return user;
+  }
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { UserService } from './user.service';
+import { UserController } from './user.controller';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { Token } from './entities/tokens.entity';
+
+@Module({
+  imports: [
+    JwtModule.registerAsync({
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('JWT_SECRET_KEY'),
+      }),
+      inject: [ConfigService],
+    }),
+    TypeOrmModule.forFeature([User, Token]),
+  ],
+  providers: [UserService, ConfigService],
+  controllers: [UserController],
+  exports: [UserService],
+})
+export class UserModule {}

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UserService],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,0 +1,89 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { Token } from './entities/tokens.entity';
+import { Repository } from 'typeorm';
+import { JwtService } from '@nestjs/jwt';
+import { compare, hash } from 'bcrypt';
+import _ from 'lodash';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class UserService {
+  constructor(
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+    @InjectRepository(Token)
+    private tokenRepository: Repository<Token>,
+    private jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async signUp(email: string, nickname: string, password: string) {
+    // 이메일 중복시 오류 처리
+    const existingEmail = await this.findByEmail(email);
+    if (existingEmail) {
+      throw new ConflictException(
+        '이미 해당 이메일로 가입된 사용자가 있습니다!',
+      );
+    }
+    // 닉네임 중복시 오류 처리
+    const existingNickname = await this.userRepository.findOne({
+      where: { nickname },
+    });
+    if (existingNickname) {
+      throw new ConflictException(
+        '이미 해당 닉네임으로 가입된 사용자가 있습니다!',
+      );
+    }
+    // 비밀번호는 해쉬하여 db에 저장
+    const hashedPassword = await hash(password, 10);
+    const savedUser = await this.userRepository.save({
+      email,
+      nickname,
+      password: hashedPassword,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { password: _, ...userWithoutPassword } = savedUser;
+    return userWithoutPassword;
+  }
+
+  async signIn(email: string, password: string) {
+    const user = await this.userRepository.findOne({
+      select: ['id', 'email', 'password'],
+      where: { email },
+    });
+    if (_.isNil(user)) {
+      throw new NotFoundException('이메일을 확인해주세요.');
+    }
+
+    if (!(await compare(password, user.password))) {
+      throw new UnauthorizedException('비밀번호를 확인해주세요.');
+    }
+    const payload = { email, sub: user.id };
+    const tokens = {
+      accessToken: this.jwtService.sign(payload, { expiresIn: '12h' }),
+      refreshToken: this.jwtService.sign(payload, {
+        secret: this.configService.get<string>('JWT_REFRESH_SECRET_KEY'),
+        expiresIn: '7d',
+      }),
+    };
+    // upsert 사용 시 conflictPaths를 인자로 넣어 줘야함. 필드명은 DB가 아닌 typeorm 코드 기준
+    await this.tokenRepository.upsert(
+      {
+        userId: user.id,
+        refreshToken: tokens.refreshToken,
+      },
+      ['userId'],
+    );
+    return tokens;
+  }
+  async findByEmail(email: string) {
+    return await this.userRepository.findOne({ where: { email } });
+  }
+}

--- a/src/utils/userInfo.decorator.ts
+++ b/src/utils/userInfo.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const UserInfo = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user ? request.user : null;
+  },
+);


### PR DESCRIPTION
- [x] 회원가입 API 구현
- [x] 로그인 API 구현
- [x] auth 관련 데코레이터, passport 전략 구현
- [x] 사용자 계정으로 로그인/회원가입 합니다.
- [x] 가입 시 100만 포인트를 지급합니다.
- [x] JWT 방식을 사용하도록 합니다.
- [x] accessToken, refrershToken  발급
- [x] token 테이블 추가
- [x] refrershToken DB 저장
- [x] Cookie가 아니라 Authorization Header를 이용한 인증 방식