### PR TITLE
feat/공연 등록 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { UserModule } from './user/user.module';
 import { User } from './user/entities/user.entity';
 import { Token } from './user/entities/tokens.entity';
 import { ShowModule } from './show/show.module';
+import { Show } from './show/entities/shows.entity';
 
 const typeOrmModuleOptions = {
   useFactory: async (
@@ -22,7 +23,7 @@ const typeOrmModuleOptions = {
     host: configService.get('DB_HOST'),
     port: configService.get('DB_PORT'),
     database: configService.get('DB_NAME'),
-    entities: [User, Token],
+    entities: [User, Token, Show],
     synchronize: configService.get('DB_SYNC'),
     logging: true,
   }),

--- a/src/auth/roles.guard.ts
+++ b/src/auth/roles.guard.ts
@@ -8,6 +8,7 @@ export class RolesGuard extends AuthGuard('jwt') implements CanActivate {
   constructor(private reflector: Reflector) {
     super();
   }
+
   async canActivate(context: ExecutionContext) {
     const authenticated = await super.canActivate(context);
     if (!authenticated) {

--- a/src/show/dto/create-show.dto.ts
+++ b/src/show/dto/create-show.dto.ts
@@ -1,0 +1,49 @@
+import {
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  Max,
+  ValidateNested,
+} from 'class-validator';
+import { ShowCategory } from '../types/show-category.type';
+import { Type } from 'class-transformer';
+import { Time } from './time.dto';
+
+export class CreateShowDto {
+  @IsString()
+  @IsNotEmpty({ message: '공연 이름을 입력해주세요.' })
+  name: string;
+
+  @IsString()
+  @IsNotEmpty({ message: '공연 설명을 입력해주세요.' })
+  description: string;
+
+  @IsEnum(ShowCategory, { message: '유효한 공연 카테고리를 선택해주세요.' })
+  @IsNotEmpty({ message: '공연 카테고리를 입력해주세요.' })
+  category: ShowCategory;
+
+  @IsString()
+  @IsNotEmpty({ message: '장소를 입력해주세요.' })
+  location: string;
+
+  @IsNumber()
+  @Max(50000, { message: '가격은 50000 이하이어야 합니다.' })
+  @IsNotEmpty({ message: '가격을 입력해주세요.' })
+  price: number;
+
+  @IsString()
+  @IsNotEmpty({ message: '이미지를 입력해주세요.' })
+  img: string;
+  // @Type(() => Time)으로 Time 타입의 유효성 검사 가능
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => Time)
+  @IsNotEmpty({ message: '시간 정보를 입력해주세요.' })
+  time: Time[];
+
+  @IsNumber()
+  @IsNotEmpty({ message: '좌석 정보를 입력해주세요.' })
+  seatInfo: number;
+}

--- a/src/show/dto/time.dto.ts
+++ b/src/show/dto/time.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class Time {
+  @IsString()
+  @IsNotEmpty({ message: '날짜를 입력해주세요.' })
+  date: string;
+
+  @IsString()
+  @IsNotEmpty({ message: '시간을 입력해주세요.' })
+  time: string;
+}

--- a/src/show/entities/shows.entity.ts
+++ b/src/show/entities/shows.entity.ts
@@ -41,7 +41,7 @@ export class Show {
   time: { date: string; time: string }[];
 
   @Column({ type: 'int', nullable: false })
-  seat_info: number;
+  seatInfo: number;
 
   @CreateDateColumn({ type: 'timestamp' })
   createdAt: Date;

--- a/src/show/show.controller.ts
+++ b/src/show/show.controller.ts
@@ -1,4 +1,32 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { ShowService } from './show.service';
+import { CreateShowDto } from './dto/create-show.dto';
+import { RolesGuard } from 'src/auth/roles.guard';
+import { Roles } from 'src/auth/roles.decorator';
+import { Role } from 'src/user/types/user-role.type';
 
+@UseGuards(RolesGuard)
 @Controller('show')
-export class ShowController {}
+export class ShowController {
+  constructor(private readonly showService: ShowService) {}
+  // 공연 등록
+  @Roles(Role.Admin)
+  @Post()
+  async createShow(@Body() createShowDto: CreateShowDto) {
+    const createdShow = await this.showService.createShow(
+      createShowDto.name,
+      createShowDto.description,
+      createShowDto.category,
+      createShowDto.location,
+      createShowDto.price,
+      createShowDto.img,
+      createShowDto.time,
+      createShowDto.seatInfo,
+    );
+    return {
+      status: HttpStatus.CREATED,
+      message: '공연 등록이 성공하였습니다.',
+      data: createdShow,
+    };
+  }
+}

--- a/src/show/show.service.ts
+++ b/src/show/show.service.ts
@@ -1,4 +1,37 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Show } from './entities/shows.entity';
+import { Repository } from 'typeorm';
+import { Time } from './dto/time.dto';
+import { ShowCategory } from './types/show-category.type';
 
 @Injectable()
-export class ShowService {}
+export class ShowService {
+  constructor(
+    @InjectRepository(Show)
+    private showRepository: Repository<Show>,
+  ) {}
+  // 공연 등록 로직
+  async createShow(
+    name: string,
+    description: string,
+    category: ShowCategory,
+    location: string,
+    price: number,
+    img: string,
+    time: Time[],
+    seatInfo: number,
+  ) {
+    const createdShow = await this.showRepository.save({
+      name,
+      description,
+      category,
+      location,
+      price,
+      img,
+      time,
+      seatInfo,
+    });
+    return createdShow;
+  }
+}


### PR DESCRIPTION
- [x] 공연 등록 API 구현
- [x] 사전에 어드민으로 지정된 유저만 해당 API를 호출 할 수 있습니다.
- [x] 유저를 어드민으로 지정하는 것 방법은 특정 컬럼에 어드민 여부 또는 역할을 저장합니다.
    - 예: users 테이블에서 is_admin 컬럼의 값이 true라면 어드민
    - 예: users 테이블의 role 컬럼의 값이 ADMIN이면 어드민
- [x] 어드민은 새로운 공연을 해당 API를 통해서 등록합니다.
- [x] 새로운 공연을 등록할 때 필요한 데이터는 다음과 같습니다.
    - [x] 공연 이름
    - [x] 공연 설명
    - [x] 공연 카테고리
    - [x] 공연 장소
    - [x] 공연 금액
    - [x] 공연 이미지
    - [x] 공연 날짜 및 시간
        - [x] 이것은 배열로 받을 수 있어야 합니다.
    - [x] 좌석 정보 (필수: 좌석 개수, 보너스: 개별 좌석에 대한 정보)
    - [x] 1석에 최대 5만 포인트까지를 상한 금액으로 설정
- [x] 공연 시간 배열 내 각 요소 유효성 검사