### PR TITLE
feat/공연 목록 조회 API

### DIFF
--- a/src/show/dto/get-list-query.dto.ts
+++ b/src/show/dto/get-list-query.dto.ts
@@ -1,0 +1,8 @@
+import { IsEnum, IsOptional } from 'class-validator';
+import { ShowCategory } from '../types/show-category.type';
+
+export class GetListQueryDto {
+  @IsOptional()
+  @IsEnum(ShowCategory, { message: '유효한 공연 카테고리를 선택해주세요.' })
+  category?: ShowCategory;
+}

--- a/src/show/show.controller.ts
+++ b/src/show/show.controller.ts
@@ -1,17 +1,27 @@
-import { Body, Controller, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpStatus,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { ShowService } from './show.service';
 import { CreateShowDto } from './dto/create-show.dto';
 import { RolesGuard } from 'src/auth/roles.guard';
 import { Roles } from 'src/auth/roles.decorator';
 import { Role } from 'src/user/types/user-role.type';
+import { GetListQueryDto } from './dto/get-list-query.dto';
 
 @UseGuards(RolesGuard)
 @Controller('show')
 export class ShowController {
   constructor(private readonly showService: ShowService) {}
-  // 공연 등록
+  // 공연 등록 API
   @Roles(Role.Admin)
   @Post()
+  // CreateShowDto 타입의 req.body 값을 createShowDto 변수에 담는다.
   async createShow(@Body() createShowDto: CreateShowDto) {
     const createdShow = await this.showService.createShow(
       createShowDto.name,
@@ -27,6 +37,16 @@ export class ShowController {
       status: HttpStatus.CREATED,
       message: '공연 등록이 성공하였습니다.',
       data: createdShow,
+    };
+  }
+  // 공연 목록 조회 API
+  @Get('list')
+  async getList(@Query() query: GetListQueryDto) {
+    const list = await this.showService.getList(query);
+    return {
+      status: HttpStatus.OK,
+      message: '공연 목록 조회를 성공했습니다.',
+      data: list,
     };
   }
 }

--- a/src/show/show.service.ts
+++ b/src/show/show.service.ts
@@ -4,6 +4,8 @@ import { Show } from './entities/shows.entity';
 import { Repository } from 'typeorm';
 import { Time } from './dto/time.dto';
 import { ShowCategory } from './types/show-category.type';
+import { GetListQueryDto } from './dto/get-list-query.dto';
+import _ from 'lodash';
 
 @Injectable()
 export class ShowService {
@@ -33,5 +35,18 @@ export class ShowService {
       seatInfo,
     });
     return createdShow;
+  }
+  // 공연 목록 조회 로직. query => GetListQueryDto { category: 'Musical' }
+  async getList(query: GetListQueryDto) {
+    const category = query.category;
+    // query 조건 없을 시 모든 목록 조회
+    if (_.isNil(category)) {
+      return await this.showRepository.find();
+    } else {
+      // 쿼리 조건에 따라 카테고리 별 목록 조회
+      return await this.showRepository.find({
+        where: { category },
+      });
+    }
   }
 }

--- a/src/show/types/show-category.type.ts
+++ b/src/show/types/show-category.type.ts
@@ -1,7 +1,7 @@
 export enum ShowCategory {
-  Musical,
-  Theater,
-  Music,
-  Entertainment,
-  None,
+  Musical = 'musical',
+  Theater = 'theater',
+  Music = 'music',
+  Entertainment = 'entertainment',
+  None = 'none',
 }

--- a/src/user/types/user-role.type.ts
+++ b/src/user/types/user-role.type.ts
@@ -1,4 +1,4 @@
 export enum Role {
-  User,
-  Admin,
+  User = 'user',
+  Admin = 'admin',
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -16,7 +16,7 @@ import { UserInfo } from 'src/utils/userInfo.decorator';
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
-  // 회원 가입
+  // 회원 가입 API
   @Post('sign-up')
   async signUp(@Body() signUpDto: SignUpDto) {
     const savedUser = await this.userService.signUp(
@@ -30,7 +30,7 @@ export class UserController {
       data: savedUser,
     };
   }
-  // 로그인
+  // 로그인 API
   @Post('sign-in')
   async signIn(@Body() signInDto: SignInDto) {
     const tokens = await this.userService.signIn(
@@ -43,7 +43,7 @@ export class UserController {
       data: tokens,
     };
   }
-  // 프로필 보기
+  // 프로필 보기 API
   @UseGuards(AuthGuard('jwt'))
   @Get('me')
   async getProfile(@UserInfo() user: User) {


### PR DESCRIPTION
- [x] 공연 조회 API 구현
- [x] 공연의 리스트를 조회합니다.
- [x] 전체, 카테고리 별로 나뉘어서 조회 가능합니다.
- [x] 카테고리는 쿼리로 받고, dto는 쿼리 타입파일을 불러와서 작성합니다.
- [x] 공연 등록 API 한정으로 어드민 인가 수정 
- [x] enum 타입 문자열로 값 할당 