### PR TITLE
feat/공연 예약

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,8 @@ import { User } from './user/entities/user.entity';
 import { Token } from './user/entities/tokens.entity';
 import { ShowModule } from './show/show.module';
 import { Show } from './show/entities/shows.entity';
+import { ReservationModule } from './reservation/reservation.module';
+import { Reservation } from './reservation/entities/reservations.entity';
 
 const typeOrmModuleOptions = {
   useFactory: async (
@@ -23,7 +25,7 @@ const typeOrmModuleOptions = {
     host: configService.get('DB_HOST'),
     port: configService.get('DB_PORT'),
     database: configService.get('DB_NAME'),
-    entities: [User, Token, Show],
+    entities: [User, Token, Show, Reservation],
     synchronize: configService.get('DB_SYNC'),
     logging: true,
   }),
@@ -48,6 +50,7 @@ const typeOrmModuleOptions = {
     AuthModule,
     UserModule,
     ShowModule,
+    ReservationModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/reservation/dto/create-reservation-params.dto.ts
+++ b/src/reservation/dto/create-reservation-params.dto.ts
@@ -1,0 +1,9 @@
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class CreateReservationParamsDto {
+  @Type(() => Number)
+  @IsNumber()
+  @IsNotEmpty({ message: '공연 ID를 입력해주세요.' })
+  id: number;
+}

--- a/src/reservation/dto/create-reservation.dto.ts
+++ b/src/reservation/dto/create-reservation.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class CreateReservationDto {
+  @IsNumber()
+  @IsNotEmpty({ message: '공연 시간을 입력해주세요.' })
+  showRound: number;
+
+  @IsNumber()
+  @IsNotEmpty({ message: '공연 시간을 입력해주세요.' })
+  seatCount: number;
+}

--- a/src/reservation/entities/reservations.entity.ts
+++ b/src/reservation/entities/reservations.entity.ts
@@ -1,0 +1,45 @@
+import { Show } from 'src/show/entities/shows.entity';
+import { User } from 'src/user/entities/user.entity';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity({
+  name: 'reservations',
+})
+export class Reservation {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'int', name: 'user_id' })
+  userId: number;
+
+  @Column({ type: 'int', name: 'show_id' })
+  showId: number;
+
+  @Column({ type: 'json', nullable: false })
+  showTime: { showRound: number; time: string };
+
+  @Column({ type: 'varchar', nullable: false })
+  location: string;
+
+  @Column({ type: 'int', nullable: false })
+  seatCount: number;
+
+  @Column({ type: 'int', nullable: false })
+  price: number;
+
+  @ManyToOne(() => User, (user) => user.reservations, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @ManyToOne(() => Show, (show) => show.reservations)
+  @JoinColumn({ name: 'show_id' })
+  show: Show;
+}

--- a/src/reservation/reservation.controller.spec.ts
+++ b/src/reservation/reservation.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReservationController } from './reservation.controller';
+
+describe('ReservationController', () => {
+  let controller: ReservationController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReservationController],
+    }).compile();
+
+    controller = module.get<ReservationController>(ReservationController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -1,0 +1,39 @@
+import {
+  Body,
+  Controller,
+  HttpStatus,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ReservationService } from './reservation.service';
+import { UserInfo } from 'src/utils/userInfo.decorator';
+import { User } from 'src/user/entities/user.entity';
+import { CreateReservationParamsDto } from './dto/create-reservation-params.dto';
+import { CreateReservationDto } from './dto/create-reservation.dto';
+
+@Controller('reservation')
+export class ReservationController {
+  constructor(private readonly reservationService: ReservationService) {}
+
+  // 공연 예매 API
+  @UseGuards(AuthGuard('jwt'))
+  @Post(':id')
+  async createReservation(
+    @UserInfo() user: User,
+    @Param() params: CreateReservationParamsDto,
+    @Body() createReservationDto: CreateReservationDto,
+  ) {
+    const reservation = await this.reservationService.createReservation(
+      user,
+      params,
+      createReservationDto,
+    );
+    return {
+      status: HttpStatus.CREATED,
+      message: '예약이 성공하였습니다.',
+      data: reservation,
+    };
+  }
+}

--- a/src/reservation/reservation.module.ts
+++ b/src/reservation/reservation.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ReservationService } from './reservation.service';
+import { ReservationController } from './reservation.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Reservation } from './entities/reservations.entity';
+import { Show } from 'src/show/entities/shows.entity';
+import { User } from 'src/user/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Reservation, Show, User])],
+  providers: [ReservationService],
+  controllers: [ReservationController],
+})
+export class ReservationModule {}

--- a/src/reservation/reservation.service.spec.ts
+++ b/src/reservation/reservation.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReservationService } from './reservation.service';
+
+describe('ReservationService', () => {
+  let service: ReservationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ReservationService],
+    }).compile();
+
+    service = module.get<ReservationService>(ReservationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/reservation/reservation.service.ts
+++ b/src/reservation/reservation.service.ts
@@ -1,0 +1,73 @@
+import { ConflictException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Reservation } from './entities/reservations.entity';
+import { DataSource, Repository } from 'typeorm';
+import { User } from 'src/user/entities/user.entity';
+import { CreateReservationParamsDto } from './dto/create-reservation-params.dto';
+import { CreateReservationDto } from './dto/create-reservation.dto';
+import { Show } from 'src/show/entities/shows.entity';
+
+@Injectable()
+export class ReservationService {
+  constructor(
+    @InjectRepository(Reservation)
+    private reservationRepository: Repository<Reservation>,
+    @InjectRepository(Show)
+    private showRepository: Repository<Show>,
+    @InjectRepository(User)
+    private UserRepository: Repository<User>,
+    private dataSource: DataSource,
+  ) {}
+  // 공연 예매 로직
+  async createReservation(
+    user: User,
+    params: CreateReservationParamsDto,
+    createReservationDto: CreateReservationDto,
+  ) {
+    // 트랜잭션 적용
+    return this.dataSource.transaction(async (manager) => {
+      const show = await manager.findOne(Show, {
+        where: { id: params.id },
+      });
+      // 예약할 공연의 회차와 좌석 수
+      const selectedShow = show.seatInfo.find(
+        (showTime) => showTime.showRound === createReservationDto.showRound,
+      );
+      // 해당 회차의 공연이 매진일 때
+      if (selectedShow.remainingSeats === 0) {
+        throw new ConflictException('해당 회차의 공연은 매진되었습니다.');
+      }
+      // 해당 회차의 잔여 좌석 수가 예매 하려는 티켓 수보다 적을 때
+      if (selectedShow.remainingSeats < createReservationDto.seatCount) {
+        throw new ConflictException('예매할 표의 수보다 잔여 좌석이 적습니다.');
+      }
+      // 사용할 유저포인트가 구매 금액보다 적을 때
+      const totalPrice = show.price * createReservationDto.seatCount;
+      if (user.point < totalPrice) {
+        throw new ConflictException('보유한 포인트가 구매 금액보다 적습니다.');
+      }
+
+      // 유저 포인트 차감
+      await manager.update(
+        User,
+        { id: user.id },
+        { point: user.point - totalPrice },
+      );
+      // 예약한 표의 수만큼 좌석 차감
+      selectedShow.remainingSeats =
+        selectedShow.remainingSeats - createReservationDto.seatCount;
+      delete show.updatedAt;
+      await manager.save(Show, show);
+      // 예약 로그 생성
+      const reservation = await manager.save(Reservation, {
+        userId: user.id,
+        showId: params.id,
+        showTime: show.showTime[createReservationDto.showRound - 1],
+        location: show.location,
+        seatCount: createReservationDto.seatCount,
+        price: totalPrice,
+      });
+      return reservation;
+    });
+  }
+}

--- a/src/show/dto/create-show.dto.ts
+++ b/src/show/dto/create-show.dto.ts
@@ -42,7 +42,7 @@ export class CreateShowDto {
   @ValidateNested({ each: true })
   @Type(() => Time)
   @IsNotEmpty({ message: '시간 정보를 입력해주세요.' })
-  time: Time[];
+  showTime: Time[];
 
   @IsArray()
   @ValidateNested({ each: true })

--- a/src/show/entities/shows.entity.ts
+++ b/src/show/entities/shows.entity.ts
@@ -2,10 +2,12 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { ShowCategory } from '../types/show-category.type';
+import { Reservation } from 'src/reservation/entities/reservations.entity';
 
 @Entity({
   name: 'shows',
@@ -38,7 +40,7 @@ export class Show {
   img: string;
 
   @Column({ type: 'json', nullable: false })
-  time: { showRound: number; time: string }[];
+  showTime: { showRound: number; time: string }[];
 
   @Column({ type: 'json', nullable: false })
   seatInfo: { showRound: number; remainingSeats: number }[];
@@ -46,6 +48,12 @@ export class Show {
   @CreateDateColumn({ type: 'timestamp' })
   createdAt: Date;
 
-  @UpdateDateColumn({ type: 'timestamp' })
+  @UpdateDateColumn({
+    type: 'timestamp',
+    precision: 6,
+  })
   updatedAt: Date;
+
+  @OneToMany(() => Reservation, (reservation) => reservation.show)
+  reservations: Reservation[];
 }

--- a/src/show/show.controller.ts
+++ b/src/show/show.controller.ts
@@ -33,7 +33,7 @@ export class ShowController {
       createShowDto.location,
       createShowDto.price,
       createShowDto.img,
-      createShowDto.time,
+      createShowDto.showTime,
       createShowDto.seatInfo,
     );
     return {

--- a/src/show/show.service.ts
+++ b/src/show/show.service.ts
@@ -24,7 +24,7 @@ export class ShowService {
     location: string,
     price: number,
     img: string,
-    time: Time[],
+    showTime: Time[],
     seatInfo: SeatInfo[],
   ) {
     const createdShow = await this.showRepository.save({
@@ -34,7 +34,7 @@ export class ShowService {
       location,
       price,
       img,
-      time,
+      showTime,
       seatInfo,
     });
     return createdShow;

--- a/src/user/entities/tokens.entity.ts
+++ b/src/user/entities/tokens.entity.ts
@@ -17,6 +17,9 @@ export class Token {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Column({ type: 'int', name: 'user_id' })
+  userId: number;
+
   @Column({ type: 'varchar', nullable: true })
   refreshToken: string;
 
@@ -32,7 +35,4 @@ export class Token {
   @OneToOne(() => User, (user) => user.token)
   @JoinColumn({ name: 'user_id' })
   user: User;
-
-  @Column({ type: 'int', name: 'user_id' })
-  userId: number;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -2,11 +2,13 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Role } from '../types/user-role.type';
 import { Token } from './tokens.entity';
+import { Reservation } from 'src/reservation/entities/reservations.entity';
 
 @Entity({
   name: 'users',
@@ -35,4 +37,7 @@ export class User {
 
   @OneToOne(() => Token, (token) => token.user)
   token: Token;
+
+  @OneToMany(() => Reservation, (reservation) => reservation.user)
+  reservations: Reservation[];
 }


### PR DESCRIPTION
- [x] 공연 예매 API 구현
- [x] 좌석을 지정하지 않고 공연 예매하기 API
    - [x] 사용자가 선택한 공연을 예매합니다.
        - 공연 당일에 현장에서 좌석이 결정된다고 가정하겠습니다. (선착순 입장, 스탠딩 공연 등)
    - [x] 예매 시 공연 시간, 장소, 티켓 수, 가격 등 정보를 반환합니다.
    - [x] 이 경우에는 좌석의 개념은 딱히 두지 않도록 하며 해당 공연 내 가격은 균일가여야 합니다.
        - [x] e.g. 공연 A → 좌석의 구분을 두지 않으며 가격은 30,000 포인트
    - [x] 보유 포인트가 공연 가격보다 낮은 경우에는 예매를 할 수 없도록 해야 합니다.
    - [x] 구매할 티켓 수가 남은 좌석의 수보다 많으면 예매를 할 수 없도록 해야 합니다.
    - [x] 예약이 이미 만석인 경우엔 예매를 할 수 없도록 합니다.
    - [x] 공연 예매 정보 생성과 포인트 차감, 좌석 차감은 트랜잭션으로 처리해야 합니다.
- [x] 예매 관련 스키마 구현
- [x] 예매 관련 파일 생성