### PR TITLE
feat/공연 예매 목록 조회

### DIFF
--- a/src/reservation/entities/reservations.entity.ts
+++ b/src/reservation/entities/reservations.entity.ts
@@ -2,6 +2,7 @@ import { Show } from 'src/show/entities/shows.entity';
 import { User } from 'src/user/entities/user.entity';
 import {
   Column,
+  CreateDateColumn,
   Entity,
   JoinColumn,
   ManyToOne,
@@ -32,6 +33,9 @@ export class Reservation {
 
   @Column({ type: 'int', nullable: false })
   price: number;
+
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt: Date;
 
   @ManyToOne(() => User, (user) => user.reservations, {
     onDelete: 'CASCADE',

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   HttpStatus,
   Param,
   Post,
@@ -13,12 +14,12 @@ import { User } from 'src/user/entities/user.entity';
 import { CreateReservationParamsDto } from './dto/create-reservation-params.dto';
 import { CreateReservationDto } from './dto/create-reservation.dto';
 
+@UseGuards(AuthGuard('jwt'))
 @Controller('reservation')
 export class ReservationController {
   constructor(private readonly reservationService: ReservationService) {}
 
   // 공연 예매 API
-  @UseGuards(AuthGuard('jwt'))
   @Post(':id')
   async createReservation(
     @UserInfo() user: User,
@@ -34,6 +35,17 @@ export class ReservationController {
       status: HttpStatus.CREATED,
       message: '예약이 성공하였습니다.',
       data: reservation,
+    };
+  }
+  // 예매 목록 조회 API
+  @Get()
+  async getReservationList(@UserInfo() user: User) {
+    const reservationList =
+      await this.reservationService.getReservationList(user);
+    return {
+      status: HttpStatus.OK,
+      message: '예약 목록 조회에 성공하였습니다.',
+      data: reservationList,
     };
   }
 }

--- a/src/reservation/reservation.service.ts
+++ b/src/reservation/reservation.service.ts
@@ -70,4 +70,12 @@ export class ReservationService {
       return reservation;
     });
   }
+  // 예약 목록 조회 로직
+  async getReservationList(user: User) {
+    const reservationList = await this.reservationRepository.find({
+      where: { userId: user.id },
+      order: { createdAt: 'DESC' },
+    });
+    return reservationList;
+  }
 }


### PR DESCRIPTION
- [x] 예매 목록 확인 API 구현
- [x] 사용자가 예매하거나 과거에 예매한 공연들의 내역을 반환합니다.
- [x] 목록은 예매 날짜 기준 최신 순으로 정렬하도록 합니다.