### PR TITLE
feat/예매 취소

### DIFF
--- a/src/reservation/dto/delete-reservation-params.dto.ts
+++ b/src/reservation/dto/delete-reservation-params.dto.ts
@@ -1,0 +1,9 @@
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class DeleteReservationParamsDto {
+  @Type(() => Number)
+  @IsNumber()
+  @IsNotEmpty({ message: '예약 로그 ID를 입력해주세요.' })
+  id: number;
+}

--- a/src/reservation/entities/reservations.entity.ts
+++ b/src/reservation/entities/reservations.entity.ts
@@ -3,6 +3,7 @@ import { User } from 'src/user/entities/user.entity';
 import {
   Column,
   CreateDateColumn,
+  DeleteDateColumn,
   Entity,
   JoinColumn,
   ManyToOne,
@@ -36,6 +37,9 @@ export class Reservation {
 
   @CreateDateColumn({ type: 'timestamp' })
   createdAt: Date;
+
+  @DeleteDateColumn({ type: 'timestamp' })
+  deletedAt: Date;
 
   @ManyToOne(() => User, (user) => user.reservations, {
     onDelete: 'CASCADE',

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpStatus,
   Param,
@@ -13,6 +14,7 @@ import { UserInfo } from 'src/utils/userInfo.decorator';
 import { User } from 'src/user/entities/user.entity';
 import { CreateReservationParamsDto } from './dto/create-reservation-params.dto';
 import { CreateReservationDto } from './dto/create-reservation.dto';
+import { DeleteReservationParamsDto } from './dto/delete-reservation-params.dto';
 
 @UseGuards(AuthGuard('jwt'))
 @Controller('reservation')
@@ -46,6 +48,22 @@ export class ReservationController {
       status: HttpStatus.OK,
       message: '예약 목록 조회에 성공하였습니다.',
       data: reservationList,
+    };
+  }
+  // 예매 취소 API
+  @Delete(':id')
+  async deleteReservation(
+    @UserInfo() user: User,
+    @Param() params: DeleteReservationParamsDto,
+  ) {
+    const deletedReservation = await this.reservationService.deleteReservation(
+      user,
+      params,
+    );
+    return {
+      status: HttpStatus.OK,
+      message: '예약 취소에 성공하였습니다.',
+      data: deletedReservation,
     };
   }
 }


### PR DESCRIPTION
- [x] 예매 취소 API 구현
- [x] 사용자가 선택한 예매를 취소합니다.
- [x] 취소 확인 메시지를 포함합니다.
- [x] 공연 시작 3시간 전까지만 예매를 취소할 수 있습니다.
- [x] 예매 취소 후 예매에 쓰였던 포인트는 환불이 되어야 합니다.
- [x] 트랜지션 구현
- [x] soft-delete 구현