### PR TITLE
feat/지정 좌석 예약 API, 예약 취소 API 로직 변경

### DIFF
--- a/src/reservation/dto/create-reservation-params.dto.ts
+++ b/src/reservation/dto/create-reservation-params.dto.ts
@@ -4,6 +4,6 @@ import { IsNotEmpty, IsNumber } from 'class-validator';
 export class CreateReservationParamsDto {
   @Type(() => Number)
   @IsNumber()
-  @IsNotEmpty({ message: '공연 ID를 입력해주세요.' })
+  @IsNotEmpty({ message: '공연 시간 ID를 입력해주세요.' })
   id: number;
 }

--- a/src/reservation/dto/create-reservation.dto.ts
+++ b/src/reservation/dto/create-reservation.dto.ts
@@ -1,12 +1,8 @@
-import { IsArray, IsDate, IsNotEmpty, ValidateNested } from 'class-validator';
+import { ArrayMinSize, ArrayNotEmpty, IsNumber } from 'class-validator';
 
 export class CreateReservationDto {
-  @IsDate()
-  @IsNotEmpty({ message: '공연 시간을 입력해주세요.' })
-  showTime: Date;
-
-  @IsArray()
-  @ValidateNested({ each: true })
-  @IsNotEmpty({ message: '예매할 좌석을 입력해주세요.' })
+  @ArrayNotEmpty({ message: '예매할 좌석을 입력해주세요.' })
+  @ArrayMinSize(1, { message: '적어도 하나 이상의 좌석을 입력해주세요.' })
+  @IsNumber({}, { each: true, message: '좌석 ID는 숫자여야 합니다.' })
   seats: number[];
 }

--- a/src/reservation/entities/reservations.entity.ts
+++ b/src/reservation/entities/reservations.entity.ts
@@ -1,4 +1,4 @@
-import { Show } from 'src/show/entities/shows.entity';
+import { ShowTime } from 'src/show/entities/show_times.entity';
 import { User } from 'src/user/entities/user.entity';
 import {
   Column,
@@ -20,11 +20,11 @@ export class Reservation {
   @Column({ type: 'int', name: 'user_id' })
   userId: number;
 
-  @Column({ type: 'int', name: 'show_id' })
-  showId: number;
+  @Column({ type: 'int', name: 'show_time_id' })
+  showTimeId: number;
 
-  @Column({ type: 'varchar', nullable: false })
-  venue: string;
+  @Column({ type: 'int', name: 'venue_id' })
+  venueId: number;
 
   @Column({ type: 'int', nullable: false })
   price: number;
@@ -41,7 +41,7 @@ export class Reservation {
   @JoinColumn({ name: 'user_id' })
   user: User;
 
-  @ManyToOne(() => Show, (show) => show.reservations)
-  @JoinColumn({ name: 'show_id' })
-  show: Show;
+  @ManyToOne(() => ShowTime, (showTime) => showTime.reservations)
+  @JoinColumn({ name: 'show_time_id' })
+  showTime: ShowTime;
 }

--- a/src/reservation/reservation.controller.ts
+++ b/src/reservation/reservation.controller.ts
@@ -13,10 +13,10 @@ import { ReservationService } from './reservation.service';
 import { UserInfo } from 'src/utils/userInfo.decorator';
 import { User } from 'src/user/entities/user.entity';
 import { CreateReservationParamsDto } from './dto/create-reservation-params.dto';
-import { CreateReservationDto } from './dto/create-reservation.dto';
 import { DeleteReservationParamsDto } from './dto/delete-reservation-params.dto';
 import { GetVacantSeatsParamsDto } from 'src/reservation/dto/get-vacant-seats-params.dto';
 import { GetVacantSeatsDto } from 'src/reservation/dto/get-vacant-seats.dto';
+import { CreateReservationDto } from './dto/create-reservation.dto';
 
 @UseGuards(AuthGuard('jwt'))
 @Controller('reservation')
@@ -28,12 +28,12 @@ export class ReservationController {
   async createReservation(
     @UserInfo() user: User,
     @Param() params: CreateReservationParamsDto,
-    @Body() createReservationDto: CreateReservationDto,
+    @Body() body: CreateReservationDto,
   ) {
     const reservation = await this.reservationService.createReservation(
       user,
       params,
-      createReservationDto,
+      body,
     );
     return {
       status: HttpStatus.CREATED,

--- a/src/show/entities/show_times.entity.ts
+++ b/src/show/entities/show_times.entity.ts
@@ -8,6 +8,7 @@ import {
 } from 'typeorm';
 import { Show } from './shows.entity';
 import { Seat } from './seats.entity';
+import { Reservation } from 'src/reservation/entities/reservations.entity';
 
 @Entity({
   name: 'show_times',
@@ -31,4 +32,7 @@ export class ShowTime {
 
   @OneToMany(() => Seat, (seat) => seat.showTime)
   seats: Seat[];
+
+  @OneToMany(() => Reservation, (reservation) => reservation.showTime)
+  reservations: Reservation[];
 }

--- a/src/show/entities/shows.entity.ts
+++ b/src/show/entities/shows.entity.ts
@@ -9,7 +9,6 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { ShowCategory } from '../types/show-category.type';
-import { Reservation } from 'src/reservation/entities/reservations.entity';
 import { ShowTime } from './show_times.entity';
 import { Venue } from './venues.entity';
 
@@ -51,9 +50,6 @@ export class Show {
     precision: 6,
   })
   updatedAt: Date;
-
-  @OneToMany(() => Reservation, (reservation) => reservation.show)
-  reservations: Reservation[];
 
   @OneToMany(() => ShowTime, (showTime) => showTime.show)
   showTimes: ShowTime[];


### PR DESCRIPTION
- [x] 좌석을 지정하여 예매할 수 있게 API 리팩토링
- [x] 예약 취소 API 로직 변경
- [x] 선택한 좌석의 예매 여부를 확인하고 예매 상태를 업데이트합니다.
- [x] 동시성 처리
    -  [x] 다른 사용자가 동시에 같은 좌석을 예매하려 할 경우엔 다음과 같은 방식으로 합니다.
        - 먼저 요청한 사용자에게 좌석을 할당합니다.
        - 나머지 사용자에게는 예매 실패 메시지를 반환합니다.
    - [X] 좌석을 지정하여 예매하기 API에서는 반드시 호출 직전에 예매 여부를 다시 체크해야 합니다.